### PR TITLE
Implement Azure AI endpoints

### DIFF
--- a/src/main/php/com/openai/rest/ApiEndpoint.class.php
+++ b/src/main/php/com/openai/rest/ApiEndpoint.class.php
@@ -1,0 +1,29 @@
+<?php namespace com\openai\rest;
+
+use webservices\rest\Endpoint;
+
+/** Base class for AzureAI and OpenAI endpoints */
+abstract class ApiEndpoint {
+  protected $endpoint;
+
+  /** Creates a new API endpoint */
+  public function __construct(Endpoint $endpoint) { $this->endpoint= $endpoint; }
+
+  /** @return util.URI */
+  public function base() { return $this->endpoint->base(); }
+
+  /** @return [:var] */
+  public function headers() { return $this->endpoint->headers(); }
+
+  /**
+   * Provides a log category for tracing requests
+   *
+   * @param  ?util.log.LogCategory $cat
+   */
+  public function setTrace($cat) {
+    $this->endpoint->setTrace($cat);
+  }
+
+  /** Returns an API */
+  public abstract function api(string $path, array $segments= []): Api;
+}

--- a/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
+++ b/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
@@ -1,0 +1,35 @@
+<?php namespace com\openai\rest;
+
+use util\URI;
+use webservices\rest\Endpoint;
+
+/**
+ * Azure OpenAI REST API endpoint
+ *
+ * @test com.openai.unittest.AzureAIEndpointTest
+ */
+class AzureAIEndpoint extends ApiEndpoint {
+  public $version;
+
+  /**
+   * Creates a new OpenAI endpoint
+   *
+   * @param  string|util.URI|webservices.rest.Endpoint
+   * @param  ?string $version API version
+   */
+  public function __construct($arg, $version= null) {
+    if ($arg instanceof Endpoint) {
+      parent::__construct($arg);
+      $this->version= $version;
+    } else {
+      $uri= $arg instanceof URI ? $arg : new URI($arg);
+      $this->version= $version ?? $uri->param('api-version');
+      parent::__construct((new Endpoint($uri))->with(['Authorization' => null, 'API-Key' => $uri->user()]));
+    }
+  }
+
+  /** Returns an API */
+  public function api(string $path, array $segments= []): Api {
+    return new Api($this->endpoint->resource(ltrim($path, '/').'?api-version='.$this->version, $segments));
+  }
+}

--- a/src/main/php/com/openai/rest/OpenAIEndpoint.class.php
+++ b/src/main/php/com/openai/rest/OpenAIEndpoint.class.php
@@ -1,6 +1,5 @@
 <?php namespace com\openai\rest;
 
-use util\log\Traceable;
 use webservices\rest\Endpoint;
 
 /**
@@ -8,8 +7,7 @@ use webservices\rest\Endpoint;
  *
  * @test com.openai.unittest.OpenAIEndpointTest
  */
-class OpenAIEndpoint implements Traceable {
-  private $endpoint;
+class OpenAIEndpoint extends ApiEndpoint {
 
   /**
    * Creates a new OpenAI endpoint
@@ -17,16 +15,7 @@ class OpenAIEndpoint implements Traceable {
    * @param  string|util.URI|webservices.rest.Endpoint
    */
   public function __construct($arg) {
-    $this->endpoint= $arg instanceof Endpoint ? $arg : new Endpoint($arg);
-  }
-
-  /**
-   * Provides a log category for tracing requests
-   *
-   * @param  ?util.log.LogCategory $cat
-   */
-  public function setTrace($cat) {
-    $this->endpoint->setTrace($cat);
+    parent::__construct($arg instanceof Endpoint ? $arg : new Endpoint($arg));
   }
 
   /** Returns an API */

--- a/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
@@ -1,0 +1,56 @@
+<?php namespace com\openai\unittest;
+
+use test\{Assert, Expect, Test};
+use webservices\rest\{TestEndpoint, UnexpectedStatus};
+
+abstract class ApiEndpointTest {
+  const URI= 'https://1e51...@test.openai.azure.com/openai/deployments/omni';
+
+  /** @return com.openai.rest.ApiEndpoint */
+  protected abstract function fixture($endpoint);
+
+  /** Returns a testing API endpoint */
+  private function testingEndpoint(): TestEndpoint {
+    return new TestEndpoint([
+      'POST /chat/completions' => function($call) {
+        if ($call->request()->payload()->value()['stream'] ?? false) {
+          $headers= ['Content-Type' => 'text/event-stream'];
+          $payload= implode("\n", [
+            'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+            'data: {"choices":[{"delta":{"content":"Test"}}]}',
+            'data: [DONE]',
+          ]);
+        } else {
+          $headers= ['Content-Type' => 'application/json'];
+          $payload= '{"choices":[{"message":{"role":"assistant","content":"Test"}}]}';
+        }
+
+        return $call->respond(200, 'OK', $headers, $payload);
+      }
+    ]);
+  }
+
+  #[Test]
+  public function invoke() {
+    $endpoint= $this->fixture($this->testingEndpoint());
+    Assert::equals(
+      ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Test']]]],
+      $endpoint->api('/chat/completions')->invoke(['stream' => false])
+    );
+  }
+
+  #[Test]
+  public function stream() {
+    $endpoint= $this->fixture($this->testingEndpoint());
+    Assert::equals(
+      ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Test']]]],
+      $endpoint->api('/chat/completions')->stream(['stream' => true])->result()
+    );
+  }
+
+  #[Test, Expect(UnexpectedStatus::class)]
+  public function invoke_non_existant_api() {
+    $endpoint= $this->fixture($this->testingEndpoint());
+    $endpoint->api('/non-exisant')->invoke([]);
+  }
+}

--- a/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
@@ -7,7 +7,7 @@ abstract class ApiEndpointTest {
   const URI= 'https://1e51...@test.openai.azure.com/openai/deployments/omni';
 
   /** @return com.openai.rest.ApiEndpoint */
-  protected abstract function fixture($endpoint);
+  protected abstract function fixture(... $args);
 
   /** Returns a testing API endpoint */
   private function testingEndpoint(): TestEndpoint {

--- a/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
@@ -4,7 +4,6 @@ use test\{Assert, Expect, Test};
 use webservices\rest\{TestEndpoint, UnexpectedStatus};
 
 abstract class ApiEndpointTest {
-  const URI= 'https://1e51...@test.openai.azure.com/openai/deployments/omni';
 
   /** @return com.openai.rest.ApiEndpoint */
   protected abstract function fixture(... $args);

--- a/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
@@ -7,11 +7,16 @@ class AzureAIEndpointTest extends ApiEndpointTest {
   const URI= 'https://1e51...@test.openai.azure.com/openai/deployments/omni';
 
   /** @return com.openai.rest.ApiEndpoint */
-  protected function fixture($endpoint) { return new AzureAIEndpoint($endpoint); }
+  protected function fixture(... $args) { return new AzureAIEndpoint(...$args); }
 
   #[Test]
   public function can_create() {
     $this->fixture(self::URI);
+  }
+
+  #[Test]
+  public function version() {
+    Assert::equals('2024-02-01', $this->fixture(self::URI, '2024-02-01')->version);
   }
 
   #[Test]

--- a/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
@@ -1,0 +1,26 @@
+<?php namespace com\openai\unittest;
+
+use com\openai\rest\AzureAIEndpoint;
+use test\{Assert, Test};
+
+class AzureAIEndpointTest extends ApiEndpointTest {
+  const URI= 'https://1e51...@test.openai.azure.com/openai/deployments/omni';
+
+  /** @return com.openai.rest.ApiEndpoint */
+  protected function fixture($endpoint) { return new AzureAIEndpoint($endpoint); }
+
+  #[Test]
+  public function can_create() {
+    $this->fixture(self::URI);
+  }
+
+  #[Test]
+  public function version_extracted_from_uri() {
+    Assert::equals('2024-02-01', $this->fixture(self::URI.'?api-version=2024-02-01')->version);
+  }
+
+  #[Test]
+  public function api_key_header_set() {
+    Assert::equals('1e51...', $this->fixture(self::URI)->headers()['API-Key']);
+  }
+}

--- a/src/test/php/com/openai/unittest/OpenAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/OpenAIEndpointTest.class.php
@@ -1,60 +1,21 @@
 <?php namespace com\openai\unittest;
 
 use com\openai\rest\OpenAIEndpoint;
-use test\{Assert, Expect, Test};
-use util\log\{LogCategory, BufferedAppender};
-use webservices\rest\{TestEndpoint, UnexpectedStatus};
+use test\{Assert, Test};
 
-class OpenAIEndpointTest {
+class OpenAIEndpointTest extends ApiEndpointTest {
   const URI= 'https://sk-test@api.openai.example.com/v1';
 
-  /** Returns a testing API endpoint */
-  private function testingEndpoint(): TestEndpoint {
-    return new TestEndpoint([
-      'POST /chat/completions' => function($call) {
-        if ($call->request()->payload()->value()['stream'] ?? false) {
-          $headers= ['Content-Type' => 'text/event-stream'];
-          $payload= implode("\n", [
-            'data: {"choices":[{"delta":{"role":"assistant"}}]}',
-            'data: {"choices":[{"delta":{"content":"Test"}}]}',
-            'data: [DONE]',
-          ]);
-        } else {
-          $headers= ['Content-Type' => 'application/json'];
-          $payload= '{"choices":[{"message":{"role":"assistant","content":"Test"}}]}';
-        }
-
-        return $call->respond(200, 'OK', $headers, $payload);
-      }
-    ]);
-  }
+  /** @return com.openai.rest.ApiEndpoint */
+  protected function fixture($endpoint) { return new OpenAIEndpoint($endpoint); }
 
   #[Test]
   public function can_create() {
-    new OpenAIEndpoint(self::URI);
+    $this->fixture(self::URI);
   }
 
   #[Test]
-  public function invoke() {
-    $endpoint= new OpenAIEndpoint($this->testingEndpoint());
-    Assert::equals(
-      ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Test']]]],
-      $endpoint->api('/chat/completions')->invoke(['stream' => false])
-    );
-  }
-
-  #[Test]
-  public function stream() {
-    $endpoint= new OpenAIEndpoint($this->testingEndpoint());
-    Assert::equals(
-      ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Test']]]],
-      $endpoint->api('/chat/completions')->stream(['stream' => true])->result()
-    );
-  }
-
-  #[Test, Expect(UnexpectedStatus::class)]
-  public function invoke_non_existant_api() {
-    $endpoint= new OpenAIEndpoint($this->testingEndpoint());
-    $endpoint->api('/non-exisant')->invoke([]);
+  public function authorization_header_set() {
+    Assert::equals('Bearer sk-test', $this->fixture(self::URI)->headers()['Authorization']);
   }
 }

--- a/src/test/php/com/openai/unittest/OpenAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/OpenAIEndpointTest.class.php
@@ -7,7 +7,7 @@ class OpenAIEndpointTest extends ApiEndpointTest {
   const URI= 'https://sk-test@api.openai.example.com/v1';
 
   /** @return com.openai.rest.ApiEndpoint */
-  protected function fixture($endpoint) { return new OpenAIEndpoint($endpoint); }
+  protected function fixture(... $args) { return new OpenAIEndpoint(...$args); }
 
   #[Test]
   public function can_create() {


### PR DESCRIPTION
These differ in the way they pass the API key and that they need an API version:

```diff
- use com\openai\rest\OpenAIEndpoint;
+ use com\openai\rest\AzureAIEndpoint;

- new OpenAIEndpoint('https://APIKEY@api.openai.com/v1');
+ new AzureAIEndpoint('https://APIKEY@example.openai.azure.com/openai/deployments/gpt-4-mini', '2024-02-01');
```

Otherwise, the code is the same.