### PR TITLE
Add Api::transmit() to invoke API and return response

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ Console::writeLine($ai->api('/embeddings')->invoke([
 ));
 ```
 
+Text to speech
+--------------
+To stream generate audio, use the API's *transmit()* method, which sends the given payload and returns the response. See https://platform.openai.com/docs/guides/text-to-speech/overview
+
+```php
+use util\cmd\Console;
+use com\openai\rest\OpenAIEndpoint;
+
+$ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
+$payload= [
+  'input' => $input,
+  'voice' => 'alloy',
+  'model' => 'tts-1',
+];
+
+$stream= $ai->api('/audio/speech')->transmit($payload)->stream();
+while ($stream->available()) {
+  Console::write($stream->read());
+}
+```
+
 Tracing the calls
 -----------------
 REST API calls can be traced with the [logging library](https://github.com/xp-framework/logging):

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -1,6 +1,6 @@
 <?php namespace com\openai\rest;
 
-use webservices\rest\{RestResource, UnexpectedStatus};
+use webservices\rest\{RestResource, RestResponse, UnexpectedStatus};
 
 class Api {
   private $resource;
@@ -8,6 +8,17 @@ class Api {
   /** Creates a new API instance from a given REST resource */
   public function __construct(RestResource $resource) {
     $this->resource= $resource;
+  }
+
+  /** Transmits given payload to the API and returns response */
+  public function transmit($payload): RestResponse {
+    $r= $this->resource
+      ->accepting('application/json')
+      ->post($payload, 'application/json')
+    ;
+    if (200 === $r->status()) return $r;
+
+    throw new UnexpectedStatus($r);
   }
 
   /** Invokes API and returns result */

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -17,6 +17,7 @@ class Api {
    *
    * @param  var $payload
    * @return webservices.rest.RestResponse
+   * @throws webservices.rest.UnexpectedStatus
    */
   public function transmit($payload): RestResponse {
     $r= $this->resource->post($payload, self::JSON);
@@ -27,23 +28,13 @@ class Api {
 
   /** Invokes API and returns result */
   public function invoke(array $payload) {
-    $r= $this->resource
-      ->accepting(self::JSON)
-      ->post(['stream' => false] + $payload, self::JSON)
-    ;
-    if (200 === $r->status()) return $r->value();
-
-    throw new UnexpectedStatus($r);
+    $this->resource->accepting(self::JSON);
+    return $this->transmit(['stream' => false] + $payload)->value();
   }
 
   /** Streams API response */
   public function stream(array $payload): EventStream {
-    $r= $this->resource
-      ->accepting('text/event-stream')
-      ->post(['stream' => true] + $payload, self::JSON)
-    ;
-    if (200 === $r->status()) return new EventStream($r->stream());
-
-    throw new UnexpectedStatus($r);
+    $this->resource->accepting('text/event-stream');
+    return new EventStream($this->transmit(['stream' => true] + $payload)->stream());
   }
 }

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -12,12 +12,14 @@ class Api {
     $this->resource= $resource;
   }
 
-  /** Transmits given payload to the API and returns response */
+  /**
+   * Transmits given payload to the API and returns response
+   *
+   * @param  var $payload
+   * @return webservices.rest.RestResponse
+   */
   public function transmit($payload): RestResponse {
-    $r= $this->resource
-      ->accepting(self::JSON)
-      ->post($payload, self::JSON)
-    ;
+    $r= $this->resource->post($payload, self::JSON);
     if (200 === $r->status()) return $r;
 
     throw new UnexpectedStatus($r);

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -3,6 +3,8 @@
 use webservices\rest\{RestResource, RestResponse, UnexpectedStatus};
 
 class Api {
+  const JSON= 'application/json';
+
   private $resource;
 
   /** Creates a new API instance from a given REST resource */
@@ -13,8 +15,8 @@ class Api {
   /** Transmits given payload to the API and returns response */
   public function transmit($payload): RestResponse {
     $r= $this->resource
-      ->accepting('application/json')
-      ->post($payload, 'application/json')
+      ->accepting(self::JSON)
+      ->post($payload, self::JSON)
     ;
     if (200 === $r->status()) return $r;
 
@@ -24,8 +26,8 @@ class Api {
   /** Invokes API and returns result */
   public function invoke(array $payload) {
     $r= $this->resource
-      ->accepting('application/json')
-      ->post(['stream' => false] + $payload, 'application/json')
+      ->accepting(self::JSON)
+      ->post(['stream' => false] + $payload, self::JSON)
     ;
     if (200 === $r->status()) return $r->value();
 
@@ -36,7 +38,7 @@ class Api {
   public function stream(array $payload): EventStream {
     $r= $this->resource
       ->accepting('text/event-stream')
-      ->post(['stream' => true] + $payload, 'application/json')
+      ->post(['stream' => true] + $payload, self::JSON)
     ;
     if (200 === $r->status()) return new EventStream($r->stream());
 

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -16,11 +16,12 @@ class Api {
    * Transmits given payload to the API and returns response
    *
    * @param  var $payload
+   * @param  string $mime Defaults to JSON
    * @return webservices.rest.RestResponse
    * @throws webservices.rest.UnexpectedStatus
    */
-  public function transmit($payload): RestResponse {
-    $r= $this->resource->post($payload, self::JSON);
+  public function transmit($payload, $mime= self::JSON): RestResponse {
+    $r= $this->resource->post($payload, $mime);
     if (200 === $r->status()) return $r;
 
     throw new UnexpectedStatus($r);

--- a/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/ApiEndpointTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace com\openai\unittest;
 
+use io\streams\Streams;
 use test\{Assert, Expect, Test};
 use webservices\rest\{TestEndpoint, UnexpectedStatus};
 
@@ -44,6 +45,15 @@ abstract class ApiEndpointTest {
     Assert::equals(
       ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Test']]]],
       $endpoint->api('/chat/completions')->stream(['stream' => true])->result()
+    );
+  }
+
+  #[Test]
+  public function transmit() {
+    $endpoint= $this->fixture($this->testingEndpoint());
+    Assert::equals(
+      '{"choices":[{"message":{"role":"assistant","content":"Test"}}]}',
+      Streams::readAll($endpoint->api('/chat/completions')->transmit([])->stream())
     );
   }
 


### PR DESCRIPTION
This can be used to stream audio, for example:

```php
use util\cmd\Console;
use com\openai\rest\OpenAIEndpoint;

$ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
$payload= [
  'input' => $input,
  'voice' => 'alloy',
  'model' => 'tts-1',
];

$stream= $ai->api('/audio/speech')->transmit($payload)->stream();
while ($stream->available()) {
  Console::write($stream->read());
}
```

See also https://platform.openai.com/docs/guides/text-to-speech/overview