### PR TITLE
Wrap function calling including error handling in `Calls` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ if ('tool_calls' === ($result['choices'][0]['finish_reason'] ?? null)) {
   $payload['messages'][]= $result['choices'][0]['message'];
   
   foreach ($result['choices'][0]['message']['tool_calls'] as $call) {
-    $return= $calls->invoke($call['function']['name'], $call['function']['arguments']);
+    $return= $calls->call($call['function']['name'], $call['function']['arguments']);
     $payload['messages'][]= [
       'role'         => 'tool',
       'tool_call_id' => $call['id'],

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -54,17 +54,13 @@ class Calls {
       $annotations= $reflect->annotations();
       if ($annotation= $annotations->type(Context::class)) {
         $ptr= &$context;
-        $annotated= $annotation->arguments();
-      } else if ($annotation= $annotations->type(Param::class)) {
-        $ptr= &$arguments;
-        $annotated= $annotation->arguments();
+        $named= $annotation->argument('name') ?? $annotation->argument(0) ?? $param;
       } else {
         $ptr= &$arguments;
-        $annotated= [];
+        $named= $param;
       }
 
       // Support NULL inside context or arguments
-      $named= $annotated['name'] ?? $annotated[0] ?? $param;
       if (array_key_exists($named, $ptr)) {
         $pass[]= $ptr[$named];
       } else if ($reflect->optional()) {

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -54,16 +54,17 @@ class Calls {
       $annotations= $reflect->annotations();
       if ($annotation= $annotations->type(Context::class)) {
         $ptr= &$context;
-        $named= $annotation->argument('name') ?? $annotation->argument(0) ?? $param;
+        $annotated= $annotation->arguments();
       } else if ($annotation= $annotations->type(Param::class)) {
         $ptr= &$arguments;
-        $named= $annotation->argument('name') ?? $annotation->argument(0) ?? $param;
+        $annotated= $annotation->arguments();
       } else {
         $ptr= &$arguments;
-        $named= $param;
+        $annotated= [];
       }
 
       // Support NULL inside context or arguments
+      $named= $annotated['name'] ?? $annotated[0] ?? $param;
       if (array_key_exists($named, $ptr)) {
         $pass[]= $ptr[$named];
       } else if ($reflect->optional()) {

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -80,7 +80,7 @@ class Calls {
    */
   public function call($name, $arguments, $context= []) {
     try {
-      $result= $this->invoke($name, json_decode($arguments, true), $context);
+      $result= $this->invoke($name, json_decode($arguments, null, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR), $context);
     } catch (TargetException $e) {
       $result= $this->error($e->getCause());
     } catch (Any $e) {

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -51,18 +51,25 @@ class Calls {
 
     $pass= [];
     foreach ($method->parameters() as $param => $reflect) {
-      if ($reflect->annotations()->provides(Context::class)) {
+      $annotations= $reflect->annotations();
+      if ($annotation= $annotations->type(Context::class)) {
         $ptr= &$context;
+        $named= $annotation->argument('name') ?? $annotation->argument(0) ?? $param;
+      } else if ($annotation= $annotations->type(Param::class)) {
+        $ptr= &$arguments;
+        $named= $annotation->argument('name') ?? $annotation->argument(0) ?? $param;
       } else {
         $ptr= &$arguments;
+        $named= $param;
       }
 
-      if (array_key_exists($param, $ptr)) {
-        $pass[]= $ptr[$param];
+      // Support NULL inside context or arguments
+      if (array_key_exists($named, $ptr)) {
+        $pass[]= $ptr[$named];
       } else if ($reflect->optional()) {
         $pass[]= $reflect->default();
       } else {
-        throw new IllegalArgumentException("Missing argument {$param} for {$name}");
+        throw new IllegalArgumentException("Missing argument {$named} for {$name}");
       }
     }
 

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -1,0 +1,58 @@
+<?php namespace com\openai\tools;
+
+use Throwable as Any;
+use lang\Throwable;
+use lang\reflection\TargetException;
+
+/** @test com.openai.unittest.CallsTest */
+class Calls {
+  private $functions;
+  private $catch= null;
+
+  /** Creates a new instance */
+  public function __construct(Functions $functions) { $this->functions= $functions; }
+
+  /**
+   * Pass an error handler
+   *
+   * @param  function(lang.Throwable): var $handler
+   * @return self
+   */
+  public function catching(callable $handler): self {
+    $this->catch= $handler;
+    return $this;
+  }
+
+  /**
+   * Converts a Throwable instance to an error representation
+   *
+   * @param  lang.Throwable
+   * @return var
+   */
+  private function error($t) {
+    return ($this->catch ? ($this->catch)($t) : null) ?? [
+      'error'   => nameof($t),
+      'message' => $t->getMessage()
+    ];
+  }
+
+  /**
+   * Invoke the function, including handling JSON de- and encoding
+   *
+   * @param  string $name
+   * @param  string $arguments
+   * @param  [:var] $context
+   * @return string
+   */
+  public function invoke($name, $arguments, $context= []) {
+    try {
+      $return= $this->functions->invoke($name, json_decode($arguments, true), $context);
+    } catch (TargetException $e) {
+      $return= $this->error($e->getCause());
+    } catch (Any $e) {
+      $return= $this->error(Throwable::wrap($e));
+    }
+
+    return json_encode($return);
+  }
+}

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -48,12 +48,20 @@ class CallsTest {
     );    
   }
 
+  #[Test]
+  public function call_invalid_json() {
+    Assert::equals(
+      '{"error":"lang.Error","message":"Control character error, possibly incorrectly encoded"}',
+      (new Calls($this->functions))->call('testing_greet', '{"unclosed')
+    );
+  }
+
   #[Test, Values(['{"name":""}', '{"name":null}'])]
   public function call_converts_errors_from($arguments) {
     Assert::equals(
       '{"error":"lang.IllegalAccessException","message":"Name may not be empty!"}',
       (new Calls($this->functions))->call('testing_greet', $arguments)
-    );    
+    );
   }
 
   #[Test]

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -1,0 +1,74 @@
+<?php namespace com\openai\unittest;
+
+use com\openai\tools\{Functions, Calls};
+use lang\IllegalAccessException;
+use test\{Assert, Before, Test};
+
+class CallsTest {
+  private $functions;
+
+  #[Before]
+  public function functions() {
+    $this->functions= (new Functions())->register('testing', new class() {
+
+      /** Greets the user */
+      public function greet($name) {
+        if (empty($name)) {
+          throw new IllegalAccessException('Name may not be empty!');
+        }
+
+        return "Hello {$name}";
+      }
+    });
+  }
+
+  #[Test]
+  public function can_create() {
+    new Calls($this->functions);
+  }
+
+  #[Test]
+  public function invoke_successfully() {
+    Assert::equals(
+      '"Hello World"',
+      (new Calls($this->functions))->invoke('testing_greet', '{"name":"World"}')
+    );    
+  }
+
+  #[Test]
+  public function missing_argument() {
+    Assert::equals(
+      '{"error":"lang.IllegalArgumentException","message":"Missing argument name for testing_greet"}',
+      (new Calls($this->functions))->invoke('testing_greet', '{}')
+    );    
+  }
+
+  #[Test]
+  public function target_error() {
+    Assert::equals(
+      '{"error":"lang.IllegalAccessException","message":"Name may not be empty!"}',
+      (new Calls($this->functions))->invoke('testing_greet', '{"name":""}')
+    );    
+  }
+
+  #[Test]
+  public function catching_error() {
+    $caught= null;
+    (new Calls($this->functions))
+      ->catching(function($t) use(&$caught) { $caught= $t; })
+      ->invoke('testing_greet', '{"name":""}')
+    ;
+
+    Assert::instance(IllegalAccessException::class, $caught);    
+  }
+
+  #[Test]
+  public function modifying_error() {
+    $result= (new Calls($this->functions))
+      ->catching(fn($t) => ['error' => $t->getMessage()])
+      ->invoke('testing_greet', '{"name":""}')
+    ;
+
+    Assert::equals('{"error":"Name may not be empty!"}', $result);
+  }
+}

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -15,7 +15,7 @@ class CallsTest {
       public function greet(
         #[Param]
         $name,
-        #[Context]
+        #[Context('phrase')]
         $greeting= 'Hello'
       ) {
         if (empty($name)) {
@@ -44,7 +44,7 @@ class CallsTest {
   public function context_passed() {
     Assert::equals(
       'Hallo World',
-      (new Calls($this->functions))->invoke('testing_greet', ['name' => 'World'], ['greeting' => 'Hallo'])
+      (new Calls($this->functions))->invoke('testing_greet', ['name' => 'World'], ['phrase' => 'Hallo'])
     );
   }
 

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace com\openai\unittest;
 
 use com\openai\tools\{Functions, Calls};
-use lang\IllegalAccessException;
-use test\{Assert, Before, Test, Values};
+use lang\{IllegalAccessException, IllegalArgumentException};
+use test\{Assert, Before, Expect, Test, Values};
 
 class CallsTest {
   private $functions;
@@ -28,6 +28,19 @@ class CallsTest {
   }
 
   #[Test]
+  public function invoke_successfully() {
+    Assert::equals(
+      'Hello World',
+      (new Calls($this->functions))->invoke('testing_greet', ['name' => 'World'])
+    );    
+  }
+
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Missing argument name for testing_greet')]
+  public function missing_argument() {
+    (new Calls($this->functions))->invoke('testing_greet', []);
+  }
+
+  #[Test]
   public function call_successfully() {
     Assert::equals(
       '"Hello World"',
@@ -35,16 +48,8 @@ class CallsTest {
     );    
   }
 
-  #[Test]
-  public function missing_argument() {
-    Assert::equals(
-      '{"error":"lang.IllegalArgumentException","message":"Missing argument name for testing_greet"}',
-      (new Calls($this->functions))->call('testing_greet', '{}')
-    );    
-  }
-
   #[Test, Values(['{"name":""}', '{"name":null}'])]
-  public function target_error($arguments) {
+  public function call_converts_errors_from($arguments) {
     Assert::equals(
       '{"error":"lang.IllegalAccessException","message":"Name may not be empty!"}',
       (new Calls($this->functions))->call('testing_greet', $arguments)

--- a/src/test/php/com/openai/unittest/FunctionsTest.class.php
+++ b/src/test/php/com/openai/unittest/FunctionsTest.class.php
@@ -227,13 +227,11 @@ class FunctionsTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function unknown_namespace() {
-    $fixture= (new Functions())->with('testing', HelloWorld::class);
-    $fixture->target('unknown_hello');
+    (new Functions())->with('testing', HelloWorld::class)->target('unknown_hello');
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function unknown_method() {
-    $fixture= (new Functions())->with('testing', HelloWorld::class);
-    $fixture->target('testing_unknown');
+    (new Functions())->with('testing', HelloWorld::class)->target('testing_unknown');
   }
 }

--- a/src/test/php/com/openai/unittest/FunctionsTest.class.php
+++ b/src/test/php/com/openai/unittest/FunctionsTest.class.php
@@ -220,7 +220,7 @@ class FunctionsTest {
   #[Test, Values([[[], 'Hello World'], [['name' => 'Test'], 'Hello Test']])]
   public function invoke($arguments, $expected) {
     $fixture= (new Functions())->with('testing', HelloWorld::class);
-    $result= $fixture->invoke('testing_hello', $arguments);
+    $result= $fixture->calls()->invoke('testing_hello', $arguments);
 
     Assert::equals($expected, $result);
   }
@@ -228,12 +228,12 @@ class FunctionsTest {
   #[Test, Expect(IllegalArgumentException::class)]
   public function unknown_namespace() {
     $fixture= (new Functions())->with('testing', HelloWorld::class);
-    $fixture->invoke('unknown_hello', []);
+    $fixture->target('unknown_hello');
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function unknown_method() {
     $fixture= (new Functions())->with('testing', HelloWorld::class);
-    $fixture->invoke('testing_unknown', []);
+    $fixture->target('testing_unknown');
   }
 }


### PR DESCRIPTION
In essence, this PR simplifies function calling by handling JSON de- and encoding as well as supplying a default error handling mechanism:

## Before

```php
try {
  $return= json_encode($functions->invoke(
    $call['function']['name'],
    json_decode($call['function']['arguments'], true)
  );
} catch (Throwable $t) {
  $t->printStackTrace();
  $return= json_encode(['error' => nameof($t), 'message' => $t->getMessage()]);
}
```

## After

```php
// Setup calls
$calls= $functions->calls()->catching(fn($t) => $t->printStackTrace());

// Call the function, including handling JSON de- and encoding and converting
// caught exceptions to a serializable form.
$return= $calls->call($call['function']['name'], $call['function']['arguments']);
```