### PR TITLE
Use marshalling for function calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
     "xp-framework/logging": "^11.2",
     "xp-framework/reflection": "^3.0 | ^2.0",
+    "xp-forge/marshalling": "^2.0 | ^1.0",
     "xp-forge/rest-client": "^5.6",
     "php" : ">=7.4.0"
   },

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -5,7 +5,12 @@ use lang\reflection\TargetException;
 use lang\{Throwable, IllegalArgumentException};
 use util\data\Marshalling;
 
-/** @test com.openai.unittest.CallsTest */
+/**
+ * Function calls
+ *
+ * @test  com.openai.unittest.CallsTest
+ * @test  com.openai.unittest.MarshallingTest
+ */
 class Calls {
   private $functions, $marshalling;
   private $catch= null;

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -3,6 +3,7 @@
 use Throwable as Any;
 use lang\reflection\TargetException;
 use lang\{Type, Throwable, IllegalArgumentException};
+use text\json\Json;
 use util\data\Marshalling;
 
 /**
@@ -109,9 +110,8 @@ class Calls {
     try {
       list($instance, $method)= $this->functions->target($name);
 
-      $named= json_decode($arguments, null, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
       $pass= [];
-      foreach ($this->pass($method, $named, $context) as $type => $value) {
+      foreach ($this->pass($method, Json::read($arguments), $context) as $type => $value) {
         $pass[]= $this->marshalling->unmarshal($value, $type);
       }
       
@@ -122,6 +122,6 @@ class Calls {
       $result= $this->error(Throwable::wrap($e));
     }
 
-    return json_encode($result);
+    return Json::of($result);
   }
 }

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -86,7 +86,7 @@ class Calls {
    * @throws lang.IllegalArgumentException
    * @throws lang.reflect.TargetException
    */
-  public function invoke($name, $named, $context= []) {
+  public function invoke(string $name, array $named= [], array $context= []) {
     list($instance, $method)= $this->functions->target($name);
 
     $pass= [];
@@ -98,8 +98,9 @@ class Calls {
   }
 
   /**
-   * Call the function, including handling JSON de- and encoding and converting
-   * caught exceptions to a serializable form.
+   * Call the given function, including handling JSON de- and encoding and converting
+   * caught exceptions to a serializable form. This method is meant to be used directly
+   * by and for LLM function calling.
    */
   public function call(string $name, string $arguments, array $context= []): string {
     try {

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -108,8 +108,8 @@ class Calls {
   public function call($name, $arguments, $context= []) {
     try {
       list($instance, $method)= $this->functions->target($name);
-      $named= json_decode($arguments, null, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
 
+      $named= json_decode($arguments, null, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
       $pass= [];
       foreach ($this->pass($method, $named, $context) as $type => $value) {
         $pass[]= $this->marshalling->unmarshal($value, $type);

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -100,13 +100,8 @@ class Calls {
   /**
    * Call the function, including handling JSON de- and encoding and converting
    * caught exceptions to a serializable form.
-   *
-   * @param  string $name
-   * @param  string $arguments
-   * @param  [:var] $context
-   * @return string
    */
-  public function call($name, $arguments, $context= []) {
+  public function call(string $name, string $arguments, array $context= []): string {
     try {
       list($instance, $method)= $this->functions->target($name);
 

--- a/src/main/php/com/openai/tools/Calls.class.php
+++ b/src/main/php/com/openai/tools/Calls.class.php
@@ -115,13 +115,13 @@ class Calls {
         $pass[]= $this->marshalling->unmarshal($value, $type);
       }
       
-      $result= $this->marshalling->marshal($method->invoke($instance, $pass));
+      $result= $method->invoke($instance, $pass);
     } catch (TargetException $e) {
       $result= $this->error($e->getCause());
     } catch (Any $e) {
       $result= $this->error(Throwable::wrap($e));
     }
 
-    return Json::of($result);
+    return Json::of($this->marshalling->marshal($result));
   }
 }

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -48,7 +48,7 @@ class CallsTest {
     );
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, message: 'Missing argument name for testing_greet')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Missing argument name for greet')]
   public function missing_argument() {
     (new Calls($this->functions))->invoke('testing_greet', []);
   }

--- a/src/test/php/com/openai/unittest/CallsTest.class.php
+++ b/src/test/php/com/openai/unittest/CallsTest.class.php
@@ -64,7 +64,7 @@ class CallsTest {
   #[Test]
   public function call_invalid_json() {
     Assert::equals(
-      '{"error":"lang.Error","message":"Control character error, possibly incorrectly encoded"}',
+      '{"error":"lang.FormatException","message":"Unclosed string "}',
       (new Calls($this->functions))->call('testing_greet', '{"unclosed')
     );
   }

--- a/src/test/php/com/openai/unittest/MarshallingTest.class.php
+++ b/src/test/php/com/openai/unittest/MarshallingTest.class.php
@@ -1,0 +1,30 @@
+<?php namespace com\openai\unittest;
+
+use com\openai\tools\{Functions, Calls, Context};
+use test\{Assert, Test};
+use util\{Date, TimeZone};
+
+class MarshallingTest {
+
+  #[Test]
+  public function unmarshal_date() {
+    $calls= new Calls((new Functions())->register('testing', new class() {
+      public function date(Date $in) {
+        return $in->toString('d.m.Y');
+      }
+    }));
+
+    Assert::equals('26.10.2024', $calls->invoke('testing_date', ['in' => '2024-10-26']));
+  }
+
+  #[Test]
+  public function marshal_date() {
+    $calls= new Calls((new Functions())->register('testing', new class() {
+      public function date($in) {
+        return new Date($in, TimeZone::getByName('UTC'));
+      }
+    }));
+
+    Assert::equals('2024-10-26T00:00:00+0000', $calls->invoke('testing_date', ['in' => '2024-10-26']));
+  }
+}

--- a/src/test/php/com/openai/unittest/MarshallingTest.class.php
+++ b/src/test/php/com/openai/unittest/MarshallingTest.class.php
@@ -14,7 +14,7 @@ class MarshallingTest {
       }
     }));
 
-    Assert::equals('26.10.2024', $calls->invoke('testing_date', ['in' => '2024-10-26']));
+    Assert::equals('"26.10.2024"', $calls->call('testing_date', '{"in": "2024-10-26"}'));
   }
 
   #[Test]
@@ -25,6 +25,6 @@ class MarshallingTest {
       }
     }));
 
-    Assert::equals('2024-10-26T00:00:00+0000', $calls->invoke('testing_date', ['in' => '2024-10-26']));
+    Assert::equals('"2024-10-26T00:00:00+0000"', $calls->call('testing_date', '{"in": "2024-10-26"}'));
   }
 }


### PR DESCRIPTION
## Example

```php
use com\mongodb\{Collection, ObjectId};
use com\openai\tools\Functions;

$conn= ...
$users= $conn->collection('database', 'users');

$functions= (new Functions())->register('testing', new class($users) {
  public function __construct(private Collection $users) { }

  public function user(ObjectId $id) {
    return $this->users->find($id)->first();
  }
});

$result= $functions->calls()->call('testing_user', '{"id": "507f1f77bcf86cd799439011"}');
```

The LLM will pass a user ID per string to the function, which will unmarshal it to an `ObjectId`. The returned `Document` will be marshalled to its properties, and yielded as a JSON object.