### PR TITLE
Refactor implementation to unify tools usage for REST & realtime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
     "xp-framework/logging": "^11.2",
     "xp-framework/reflection": "^3.0 | ^2.0",
-    "xp-forge/marshalling": "^2.0 | ^1.0",
-    "xp-forge/rest-client": "^5.6",
+    "xp-forge/marshalling": "^2.3",
+    "xp-forge/rest-client": "^5.7",
     "xp-forge/websockets": "^4.0",
     "php" : ">=7.4.0"
   },

--- a/src/main/php/com/openai/Tools.class.php
+++ b/src/main/php/com/openai/Tools.class.php
@@ -19,20 +19,7 @@ class Tools {
    */
   public function __construct(...$selected) {
     foreach ($selected as $select) {
-      if ($select instanceof Functions) {
-        foreach ($select->schema() as $name => $function) {
-          $this->selection[]= ['type' => 'function', 'function' => [
-            'name'        => $name,
-            'description' => $function['description'],
-            'parameters'  => $function['input'],
-          ]];
-        }
-      } else {
-        $this->selection[]= is_string($select) ? ['type' => $select] : $select;
-      }
+      $this->selection[]= is_string($select) ? ['type' => $select] : $select;
     }
   }
-
-  /** @return var */
-  public function __serialize() { return $this->selection; }
 }

--- a/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
+++ b/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
@@ -10,8 +10,7 @@ use webservices\rest\Endpoint;
  *
  * @test com.openai.unittest.AzureAIEndpointTest
  */
-class AzureAIEndpoint extends ApiEndpoint {
-  private $endpoint, $rateLimit;
+class AzureAIEndpoint extends RestEndpoint {
   public $version;
 
   /**
@@ -22,29 +21,13 @@ class AzureAIEndpoint extends ApiEndpoint {
    */
   public function __construct($arg, $version= null) {
     if ($arg instanceof Endpoint) {
-      $this->endpoint= $arg;
       $this->version= $version;
+      parent::__construct($arg);
     } else {
       $uri= $arg instanceof URI ? $arg : new URI($arg);
       $this->version= $version ?? $uri->param('api-version');
-      $this->endpoint= (new Endpoint($uri))->with(['Authorization' => null, 'API-Key' => $uri->user()]);
+      parent::__construct((new Endpoint($uri))->with(['Authorization' => null, 'API-Key' => $uri->user()]));
     }
-    $this->rateLimit= new RateLimit();
-  }
-
-  /** Returns rate limit */
-  public function rateLimit(): RateLimit { return $this->rateLimit; }
-
-  /** @return [:var] */
-  public function headers() { return $this->endpoint->headers(); }
-
-  /**
-   * Provides a log category for tracing requests
-   *
-   * @param  ?util.log.LogCategory $cat
-   */
-  public function setTrace($cat) {
-    $this->endpoint->setTrace($cat);
   }
 
   /** Returns an API */

--- a/src/main/php/com/openai/rest/OpenAIEndpoint.class.php
+++ b/src/main/php/com/openai/rest/OpenAIEndpoint.class.php
@@ -8,8 +8,7 @@ use webservices\rest\Endpoint;
  * @see  https://platform.openai.com/docs/api-reference/authentication
  * @test com.openai.unittest.OpenAIEndpointTest
  */
-class OpenAIEndpoint extends ApiEndpoint {
-  private $endpoint, $rateLimit;
+class OpenAIEndpoint extends RestEndpoint {
 
   /**
    * Creates a new OpenAI endpoint
@@ -19,29 +18,13 @@ class OpenAIEndpoint extends ApiEndpoint {
    * @param  ?string $project
    */
   public function __construct($arg, $organization= null, $project= null) {
-    $this->endpoint= $arg instanceof Endpoint ? $arg : new Endpoint($arg);
-    $this->rateLimit= new RateLimit();
+    parent::__construct($arg instanceof Endpoint ? $arg : new Endpoint($arg));
 
     // Pass optional organization and project IDs
     $headers= [];
     $organization && $headers['OpenAI-Organization']= $organization;
     $project && $headers['OpenAI-Project']= $project;
     $headers && $this->endpoint->with($headers);
-  }
-
-  /** Returns rate limit */
-  public function rateLimit(): RateLimit { return $this->rateLimit; }
-
-  /** @return [:var] */
-  public function headers() { return $this->endpoint->headers(); }
-
-  /**
-   * Provides a log category for tracing requests
-   *
-   * @param  ?util.log.LogCategory $cat
-   */
-  public function setTrace($cat) {
-    $this->endpoint->setTrace($cat);
   }
 
   /** Returns an API */

--- a/src/main/php/com/openai/rest/RestEndpoint.class.php
+++ b/src/main/php/com/openai/rest/RestEndpoint.class.php
@@ -1,0 +1,45 @@
+<?php namespace com\openai\rest;
+
+use com\openai\Tools;
+use com\openai\tools\Functions;
+
+/** Base class for OpenAI and AzureAI implementations */
+abstract class RestEndpoint extends ApiEndpoint {
+  protected $endpoint, $rateLimit;
+
+  /** @param webservices.rest.Endpoint */
+  public function __construct($endpoint) {
+    $this->endpoint= $endpoint;
+    $this->endpoint->marshalling->mapping(Tools::class, function($tools) {
+      foreach ($tools->selection as $select) {
+        if ($select instanceof Functions) {
+          foreach ($select->schema() as $name => $function) {
+            yield ['type' => 'function', 'function' => [
+              'name'        => $name,
+              'description' => $function['description'],
+              'parameters'  => $function['input'],
+            ]];
+          }
+        } else {
+          yield $select;
+        }
+      }
+    });
+    $this->rateLimit= new RateLimit();
+  }
+
+  /** Returns rate limit */
+  public function rateLimit(): RateLimit { return $this->rateLimit; }
+
+  /** @return [:var] */
+  public function headers() { return $this->endpoint->headers(); }
+
+  /**
+   * Provides a log category for tracing requests
+   *
+   * @param  ?util.log.LogCategory $cat
+   */
+  public function setTrace($cat) {
+    $this->endpoint->setTrace($cat);
+  }
+}

--- a/src/test/php/com/openai/unittest/ToolsTest.class.php
+++ b/src/test/php/com/openai/unittest/ToolsTest.class.php
@@ -1,40 +1,86 @@
 <?php namespace com\openai\unittest;
 
 use com\openai\Tools;
+use com\openai\realtime\RealtimeApi;
+use com\openai\rest\OpenAIEndpoint;
 use com\openai\tools\Functions;
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
+use webservices\rest\TestEndpoint;
 
 class ToolsTest {
+
+  /** Returns a testing API endpoint */
+  private function testingEndpoint(): TestEndpoint {
+    return new TestEndpoint([
+      'POST /echo' => function($call) {
+        return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], $call->content());
+      }
+    ]);
+  }
+
+  /** Returns functions with a "Hello World!" registration */
+  private function functions(): Functions {
+    return (new Functions())->register('greet', new class() {
+      public function world($name= 'World') { return "Hello {$name}!"; }
+    });
+  }
 
   #[Test]
   public function can_create() {
     new Tools();
   }
 
-  #[Test]
-  public function code_interpreter() {
-    Assert::equals(
-      [['type' => 'code_interpreter']],
-      (new Tools('code_interpreter'))->selection
-    );
+  #[Test, Values([['code_interpreter'], [['type' => 'code_interpreter']]])]
+  public function code_interpreter($tool) {
+    Assert::equals([['type' => 'code_interpreter']], (new Tools($tool))->selection);
   }
 
   #[Test]
   public function with_custom_functions() {
-    $functions= (new Functions())->register('greet', new class() {
-      public function world() { return 'Hello World!'; }
-    });
+    $functions= $this->functions();
+    Assert::equals([$functions], (new Tools($functions))->selection);
+  }
+
+  #[Test]
+  public function serialized_for_rest_api() {
+    $functions= $this->functions();
+    $endpoint= new OpenAIEndpoint($this->testingEndpoint());
+    $result= $endpoint->api('/echo')->invoke(['tools' => new Tools($functions)]);
 
     Assert::equals(
-      [[
+      ['tools' => [[
         'type' => 'function',
         'function' => [
           'name'        => 'greet_world',
           'description' => 'World',
           'parameters'  => $functions->schema()->current()['input'],
         ],
-      ]],
-      (new Tools($functions))->selection
+      ]]],
+      $result
     );
+  }
+
+  #[Test]
+  public function serialized_for_realtime_api() {
+    $functions= $this->functions();
+    $api= new RealtimeApi(new TestingSocket([
+      '{"type": "session.created"}',
+      '{"type": "session.update", "session": {
+        "tools": [{
+          "type": "function",
+          "name": "greet_world",
+          "description": "World",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string", "description": "Name"}
+            },
+            "required": []
+          }
+        }]
+      }}',
+    ]));
+    $api->connect();
+    $api->send(['type' => 'session.update', 'session' => ['tools' => new Tools($functions)]]);
   }
 }


### PR DESCRIPTION
See https://github.com/xp-forge/openai/pull/15#issuecomment-2451679988

### Works
```php
$rest= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');

Console::writeLine($rest->api('/chat/completions')->invoke([
  'model'    => 'gpt-4o-mini',
  'tools'    => new Tools($functions),
  'messages' => [['role' => 'user', 'content' => $prompt]],
]));
```
### Now also works
```php
$rt= new RealtimeApi('wss://example.openai.azure.com/openai/realtime?'.
  '?api-version=2024-10-01-preview'.
  '&deployment=gpt-4o-realtime-preview'
);
$session= $rt->connect(['api-key' => getenv('AZUREAI_API_KEY')]);

Console::writeLine($rt->transmit([
  'type' => 'session.update',
  'session' => ['tools' => new Tools($functions)]
]));
```
