### PR TITLE
Move the `Tools` class to the com.openai.tools package

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ Custom functions are registered in a `Functions` instance and passed via *tools*
 
 ```php
 use com\openai\rest\OpenAIEndpoint;
-use com\openai\Tools;
-use com\openai\tools\Functions;
+use com\openai\tools\{Tools, Functions};
 
 $functions= (new Functions())->register('weather', new Weather());
 

--- a/src/main/php/com/openai/realtime/RealtimeApi.class.php
+++ b/src/main/php/com/openai/realtime/RealtimeApi.class.php
@@ -1,7 +1,6 @@
 <?php namespace com\openai\realtime;
 
-use com\openai\Tools;
-use com\openai\tools\Functions;
+use com\openai\tools\{Tools, Functions};
 use lang\{IllegalStateException, Value};
 use text\json\Json;
 use util\data\Marshalling;

--- a/src/main/php/com/openai/rest/RestEndpoint.class.php
+++ b/src/main/php/com/openai/rest/RestEndpoint.class.php
@@ -1,7 +1,6 @@
 <?php namespace com\openai\rest;
 
-use com\openai\Tools;
-use com\openai\tools\Functions;
+use com\openai\tools\{Tools, Functions};
 
 /** Base class for OpenAI and AzureAI implementations */
 abstract class RestEndpoint extends ApiEndpoint {

--- a/src/main/php/com/openai/tools/Tools.class.php
+++ b/src/main/php/com/openai/tools/Tools.class.php
@@ -1,9 +1,8 @@
-<?php namespace com\openai;
-
-use com\openai\tools\Functions;
+<?php namespace com\openai\tools;
 
 /**
- * Tools
+ * Tools incorporate the builtins like `code_interpreter` but also custom
+ * functions declared via `Functions` registry.
  *
  * @test  com.openai.unittest.ToolsTest
  * @see   https://platform.openai.com/docs/assistants/tools

--- a/src/test/php/com/openai/unittest/ToolsTest.class.php
+++ b/src/test/php/com/openai/unittest/ToolsTest.class.php
@@ -1,9 +1,8 @@
 <?php namespace com\openai\unittest;
 
-use com\openai\Tools;
 use com\openai\realtime\RealtimeApi;
 use com\openai\rest\OpenAIEndpoint;
-use com\openai\tools\Functions;
+use com\openai\tools\{Tools, Functions};
 use test\{Assert, Test, Values};
 use webservices\rest\TestEndpoint;
 


### PR DESCRIPTION
Typically, it's imported together with the *Functions* class anyway, so it's easier to write a grouped import:

```diff
- use com\openai\Tools;
- use com\openai\tools\Functions;
+ use com\openai\tools\{Tools, Functions};
```