### PR TITLE
Implement responses API streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use util\cmd\Console;
 
 $ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
 
-$events= $ai->api('/responses')->events([
+$events= $ai->api('/responses')->stream([
   'model' => 'gpt-4o-mini',
   'input' => $prompt,
 ]);

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ foreach ($events as $type => $value) {
 Console::writeLine();
 ```
 
-To access the result object after streaming, check for the *response.completed* event type and use its value. It contains the outuputs as well as model, filter results and usage information.
+To access the result object, check for the *response.completed* event type and use its value. It contains the outuputs as well as model, filter results and usage information.
 
 TikToken
 --------
@@ -255,7 +255,7 @@ class Memory {
 // ...shortened for brevity...
 
 $context= ['user' => $user];
-$return= $calls->call($call['function']['name'], $call['function']['arguments'], $context);
+$return= $calls->call($call['name'], $call['arguments'], $context);
 ```
 
 Azure OpenAI
@@ -350,6 +350,29 @@ $api= new RealtimeApi('wss://example.openai.azure.com/openai/realtime?'.
 );
 $session= $api->connect(['api-key' => getenv('AZUREAI_API_KEY')]);
 ```
+
+Completions API
+---------------
+To use the legacy (but industry standard) chat completions API:
+
+```php
+use com\openai\rest\OpenAIEndpoint;
+use util\cmd\Console;
+
+$ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
+
+$flow= $ai->api('/chat/completions')->flow([
+  'model'    => 'gpt-4o-mini',
+  'messages' => [['role' => 'user', 'content' => $prompt]],
+]);
+$flow= $ai->api('/chat/completions')->flow($payload);
+foreach ($flow->deltas() as $type => $delta) {
+  Console::writeLine('<', $type, '> ', $delta);
+}
+Console::writeLine();
+```
+
+The result object is computed from the streamed deltas and can be retrieved by accessing *$flow->result()*.
 
 See also
 --------

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -78,15 +78,15 @@ class Api {
     return $this->transmit($payload)->value();
   }
 
-  /** Streams API response */
-  public function stream(array $payload): EventStream {
-    $this->resource->accepting(self::EVENTS);
-    return new EventStream($this->transmit(['stream' => true] + $payload)->stream());
-  }
-
   /** Yields events from a streamed response */
-  public function events(array $payload): Events {
+  public function stream(array $payload): Events {
     $this->resource->accepting(self::EVENTS);
     return new Events($this->transmit(['stream' => true] + $payload)->stream());
+  }
+
+  /** Completions API flow: Yield deltas and compute result */
+  public function flow(array $payload): Flow {
+    $this->resource->accepting(self::EVENTS);
+    return new Flow($this->transmit(['stream' => true] + $payload)->stream());
   }
 }

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -4,7 +4,7 @@ use webservices\rest\{RestResource, RestResponse, RestUpload, UnexpectedStatus};
 
 class Api {
   const JSON= 'application/json';
-  const STREAMING= ['stream' => true, 'stream_options' => ['include_usage' => true]];
+  const EVENTS= 'text/event-stream';
 
   private $resource, $rateLimit;
 
@@ -52,7 +52,17 @@ class Api {
 
   /** Streams API response */
   public function stream(array $payload): EventStream {
-    $this->resource->accepting('text/event-stream');
-    return new EventStream($this->transmit(self::STREAMING + $payload)->stream());
+    static $stream= ['stream' => true, 'stream_options' => ['include_usage' => true]];
+
+    $this->resource->accepting(self::EVENTS);
+    return new EventStream($this->transmit($stream + $payload)->stream());
+  }
+
+  /** Yields events from a streamed response */
+  public function events(array $payload): Events {
+    static $stream= ['stream' => true];
+
+    $this->resource->accepting(self::EVENTS);
+    return new Events($this->transmit($stream + $payload)->stream());
   }
 }

--- a/src/main/php/com/openai/rest/Api.class.php
+++ b/src/main/php/com/openai/rest/Api.class.php
@@ -3,6 +3,7 @@
 use com\openai\tools\Functions;
 use webservices\rest\{RestResource, RestResponse, RestUpload, UnexpectedStatus};
 
+/** @see https://platform.openai.com/docs/guides/responses-vs-chat-completions */
 class Api {
   const JSON= 'application/json';
   const EVENTS= 'text/event-stream';

--- a/src/main/php/com/openai/rest/Events.class.php
+++ b/src/main/php/com/openai/rest/Events.class.php
@@ -13,6 +13,7 @@ use util\Objects;
  * @test  com.openai.unittest.EventsTest
  */
 class Events implements IteratorAggregate {
+  const DONE= '[DONE]';
   private $stream;
 
   /** Creates a new event stream */
@@ -30,7 +31,8 @@ class Events implements IteratorAggregate {
       if (0 === strncmp($line, 'event: ', 6)) {
         $event= substr($line, 7);
       } else if (0 === strncmp($line, 'data: ', 5)) {
-        yield $event => json_decode(substr($line, 6), true);
+        $data= substr($line, 6);
+        if (self::DONE !== $data) yield $event => json_decode($data, true);
         $event= null;
       }
     }

--- a/src/main/php/com/openai/rest/Events.class.php
+++ b/src/main/php/com/openai/rest/Events.class.php
@@ -28,6 +28,7 @@ class Events implements IteratorAggregate {
 
     // Read all lines starting with `event` or `data`, ignore others
     while (null !== ($line= $r->readLine())) {
+      // echo "\n<<< $line\n";
       if (0 === strncmp($line, 'event: ', 6)) {
         $event= substr($line, 7);
       } else if (0 === strncmp($line, 'data: ', 5)) {

--- a/src/main/php/com/openai/rest/Events.class.php
+++ b/src/main/php/com/openai/rest/Events.class.php
@@ -1,0 +1,38 @@
+<?php namespace com\openai\rest;
+
+use IteratorAggregate, Traversable;
+use io\streams\{InputStream, StringReader};
+use lang\IllegalStateException;
+use util\Objects;
+
+/**
+ * Streams events using SSE with JSON data
+ *
+ * @see   https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses
+ * @see   https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
+ * @test  com.openai.unittest.EventsTest
+ */
+class Events implements IteratorAggregate {
+  private $stream;
+
+  /** Creates a new event stream */
+  public function __construct(InputStream $stream) {
+    $this->stream= $stream;
+  }
+
+  /** Returns events while reading */
+  public function getIterator(): Traversable {
+    $r= new StringReader($this->stream);
+    $event= null;
+
+    // Read all lines starting with `event` or `data`, ignore others
+    while (null !== ($line= $r->readLine())) {
+      if (0 === strncmp($line, 'event: ', 6)) {
+        $event= substr($line, 7);
+      } else if (0 === strncmp($line, 'data: ', 5)) {
+        yield $event => json_decode(substr($line, 6), true);
+        $event= null;
+      }
+    }
+  }
+}

--- a/src/main/php/com/openai/rest/Flow.class.php
+++ b/src/main/php/com/openai/rest/Flow.class.php
@@ -5,7 +5,7 @@ use lang\IllegalStateException;
 use util\Objects;
 
 /**
- * OpenAI API event stream
+ * OpenAI API completion flow
  *
  * Note: While these event streams are based on server-sent events, they do not
  * utilize their full extent - there are no event types, IDs or multiline data.
@@ -13,9 +13,9 @@ use util\Objects;
  *
  * @see   https://platform.openai.com/docs/guides/production-best-practices/streaming
  * @see   https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
- * @test  com.openai.unittest.EventStreamTest
+ * @test  com.openai.unittest.FlowTest
  */
-class EventStream {
+class Flow {
   private $stream;
   private $result= null;
 

--- a/src/main/php/com/openai/rest/RestEndpoint.class.php
+++ b/src/main/php/com/openai/rest/RestEndpoint.class.php
@@ -13,11 +13,12 @@ abstract class RestEndpoint extends ApiEndpoint {
       foreach ($tools->selection as $select) {
         if ($select instanceof Functions) {
           foreach ($select->schema() as $name => $function) {
-            yield ['type' => 'function', 'function' => [
+            yield [
+              'type'        => 'function',
               'name'        => $name,
               'description' => $function['description'],
               'parameters'  => $function['input'],
-            ]];
+            ];
           }
         } else {
           yield $select;

--- a/src/test/php/com/openai/unittest/EventStreamTest.class.php
+++ b/src/test/php/com/openai/unittest/EventStreamTest.class.php
@@ -1,47 +1,11 @@
 <?php namespace com\openai\unittest;
 
 use com\openai\rest\EventStream;
-use io\streams\{InputStream, MemoryInputStream};
 use lang\IllegalStateException;
 use test\{Assert, Test, Values};
 
 class EventStreamTest {
-
-  /** Streams contents */
-  private function contentStream(): array {
-    return [
-      'data: {"choices":[{"delta":{"role":"assistant"}}]}',
-      'data: {"choices":[{"delta":{"content":"Test"}}]}',
-      'data: {"choices":[{"delta":{"content":"ed"}}]}',
-      'data: [DONE]'
-    ];
-  }
-
-  /** Streams tool calls */
-  private function toolCallStream(): array {
-    return [
-      'data: {"choices":[{"delta":{"role":"assistant"}}]}',
-      'data: {"choices":[{"delta":{"tool_calls":[{"type":"function","function":{"name":"search","arguments":""}}]}}]}',
-      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{"}}]}}]}',
-      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"}"}}]}}]}',
-      'data: {"choices":[{"delta":{},"finish_reason":"function_call"}]}',
-      'data: [DONE]'
-    ];
-  }
-
-  /** Returns input */
-  private function input(array $lines): InputStream {
-    return new MemoryInputStream(implode("\n\n", $lines));
-  }
-
-  /** Maps deltas to a list of pairs */
-  private function pairsOf(iterable $deltas): array {
-    $r= [];
-    foreach ($deltas as $field => $delta) {
-      $r[]= [$field => $delta];
-    }
-    return $r;
-  }
+  use Streams;
 
   /** Filtered deltas */
   private function filtered(): iterable {
@@ -71,13 +35,13 @@ class EventStreamTest {
   public function deltas() {
     Assert::equals(
       [['role' => 'assistant'], ['content' => 'Test'], ['content' => 'ed']],
-      $this->pairsOf((new EventStream($this->input($this->contentStream())))->deltas())
+      $this->pairsOf((new EventStream($this->input($this->contentCompletions())))->deltas())
     );
   }
 
   #[Test]
   public function deltas_throws_if_already_consumed() {
-    $events= new EventStream($this->input($this->contentStream()));
+    $events= new EventStream($this->input($this->contentCompletions()));
     iterator_count($events->deltas());
 
     Assert::throws(IllegalStateException::class, fn() => iterator_count($events->deltas()));
@@ -87,7 +51,7 @@ class EventStreamTest {
   public function ignores_newlines() {
     Assert::equals(
       [['role' => 'assistant'], ['content' => 'Test'], ['content' => 'ed']],
-      $this->pairsOf((new EventStream($this->input(['', ...$this->contentStream()])))->deltas())
+      $this->pairsOf((new EventStream($this->input(['', ...$this->contentCompletions()])))->deltas())
     );
   }
 
@@ -95,7 +59,7 @@ class EventStreamTest {
   public function filtered_deltas($filter, $expected) {
     Assert::equals(
       $expected,
-      $this->pairsOf((new EventStream($this->input($this->contentStream())))->deltas($filter))
+      $this->pairsOf((new EventStream($this->input($this->contentCompletions())))->deltas($filter))
     );
   }
 
@@ -103,7 +67,7 @@ class EventStreamTest {
   public function result() {
     Assert::equals(
       ['choices' => [['message' => ['role' => 'assistant', 'content' => 'Tested']]]],
-      (new EventStream($this->input($this->contentStream())))->result()
+      (new EventStream($this->input($this->contentCompletions())))->result()
     );
   }
 
@@ -116,7 +80,7 @@ class EventStreamTest {
         ['tool_calls' => [['function' => ['arguments' => '{']]]],
         ['tool_calls' => [['function' => ['arguments' => '}']]]],
       ],
-      $this->pairsOf((new EventStream($this->input($this->toolCallStream())))->deltas())
+      $this->pairsOf((new EventStream($this->input($this->toolCallCompletions())))->deltas())
     );
   }
 
@@ -128,7 +92,7 @@ class EventStreamTest {
         'message'       => ['role' => 'assistant', 'tool_calls' => $calls],
         'finish_reason' => 'function_call',
       ]]],
-      (new EventStream($this->input($this->toolCallStream())))->result()
+      (new EventStream($this->input($this->toolCallCompletions())))->result()
     );
   }
 }

--- a/src/test/php/com/openai/unittest/EventsTest.class.php
+++ b/src/test/php/com/openai/unittest/EventsTest.class.php
@@ -1,0 +1,82 @@
+<?php namespace com\openai\unittest;
+
+use com\openai\rest\Events;
+use io\streams\{InputStream, MemoryInputStream};
+use lang\IllegalStateException;
+use test\{Assert, Test, Values};
+
+class EventsTest {
+
+  /** Returns input */
+  private function input(array $lines): InputStream {
+    return new MemoryInputStream(implode("\n", $lines));
+  }
+
+  /** Maps events to a list of pairs */
+  private function pairsOf(iterable $events): array {
+    $r= [];
+    foreach ($events as $event => $value) {
+      $r[]= [$event => $value];
+    }
+    return $r;
+  }
+
+  #[Test]
+  public function can_create() {
+    new Events($this->input([]));
+  }
+
+  #[Test]
+  public function empty_input() {
+    Assert::equals([], $this->pairsOf(new Events($this->input([]))));
+  }
+
+  #[Test]
+  public function response_with_text_delta() {
+    Assert::equals(
+      [
+        ['response.created' => [
+          'type'          => 'response.created',
+          'response'      => ['id' => 'test'],
+        ]],
+        ['response.output_item.added' => [
+          'type'          => 'response.output_item.added',
+          'output_index'  => 0,
+          'item'          => ['type' => 'message'],
+        ]],
+        ['response.output_text.delta' => [
+          'type'          => 'response.output_text.delta',
+          'output_index'  => 0,
+          'content_index' => 0,
+          'delta'         => 'Test',
+        ]],
+        ['response.output_text.delta' => [
+          'type'          => 'response.output_text.delta',
+          'content_index' => 0,
+          'output_index'  => 0,
+          'delta'         => 'ed',
+        ]],
+        ['response.completed' => [
+          'type'          => 'response.completed',
+          'response'      => ['id' => 'test'],
+        ]],
+      ],
+      $this->pairsOf(new Events($this->input([
+        'event: response.created',
+        'data: {"type":"response.created","response":{"id":"test"}}',
+        '',
+        'event: response.output_item.added',
+        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}',
+        '',
+        'event: response.output_text.delta',
+        'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Test"}',
+        '',
+        'event: response.output_text.delta',
+        'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"ed"}',
+        '',
+        'event: response.completed',
+        'data: {"type":"response.completed","response":{"id":"test"}}'
+      ])))
+    );
+  }
+}

--- a/src/test/php/com/openai/unittest/EventsTest.class.php
+++ b/src/test/php/com/openai/unittest/EventsTest.class.php
@@ -6,20 +6,7 @@ use lang\IllegalStateException;
 use test\{Assert, Test, Values};
 
 class EventsTest {
-
-  /** Returns input */
-  private function input(array $lines): InputStream {
-    return new MemoryInputStream(implode("\n", $lines));
-  }
-
-  /** Maps events to a list of pairs */
-  private function pairsOf(iterable $events): array {
-    $r= [];
-    foreach ($events as $event => $value) {
-      $r[]= [$event => $value];
-    }
-    return $r;
-  }
+  use Streams;
 
   #[Test]
   public function can_create() {
@@ -61,22 +48,19 @@ class EventsTest {
           'response'      => ['id' => 'test'],
         ]],
       ],
-      $this->pairsOf(new Events($this->input([
-        'event: response.created',
-        'data: {"type":"response.created","response":{"id":"test"}}',
-        '',
-        'event: response.output_item.added',
-        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}',
-        '',
-        'event: response.output_text.delta',
-        'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Test"}',
-        '',
-        'event: response.output_text.delta',
-        'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"ed"}',
-        '',
-        'event: response.completed',
-        'data: {"type":"response.completed","response":{"id":"test"}}'
-      ])))
+      $this->pairsOf(new Events($this->input($this->contentResponse())))
+    );
+  }
+
+  #[Test]
+  public function can_be_used_for_completions() {
+    Assert::equals(
+      [
+        [null => ['choices' => [['delta' => ['role' => 'assistant']]]]],
+        [null => ['choices' => [['delta' => ['content' => 'Test']]]]],
+        [null => ['choices' => [['delta' => ['content' => 'ed']]]]],
+      ],
+      $this->pairsOf(new Events($this->input($this->contentCompletions())))
     );
   }
 }

--- a/src/test/php/com/openai/unittest/Streams.class.php
+++ b/src/test/php/com/openai/unittest/Streams.class.php
@@ -1,0 +1,62 @@
+<?php namespace com\openai\unittest;
+
+use io\streams\{InputStream, MemoryInputStream};
+
+trait Streams {
+
+  /** Content completions */
+  private function contentCompletions(): array {
+    return [
+      'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+      'data: {"choices":[{"delta":{"content":"Test"}}]}',
+      'data: {"choices":[{"delta":{"content":"ed"}}]}',
+      'data: [DONE]'
+    ];
+  }
+
+  /** Tool call completions */
+  private function toolCallCompletions(): array {
+    return [
+      'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+      'data: {"choices":[{"delta":{"tool_calls":[{"type":"function","function":{"name":"search","arguments":""}}]}}]}',
+      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{"}}]}}]}',
+      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"}"}}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"function_call"}]}',
+      'data: [DONE]'
+    ];
+  }
+
+  /** Content response */
+  private function contentResponse(): array {
+    return [
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"test"}}',
+      '',
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}',
+      '',
+      'event: response.output_text.delta',
+      'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Test"}',
+      '',
+      'event: response.output_text.delta',
+      'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"ed"}',
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"test"}}'
+    ];
+  }
+
+  /** Returns input */
+  private function input(array $lines): InputStream {
+    return new MemoryInputStream(implode("\n\n", $lines));
+  }
+
+  /** Maps deltas to a list of pairs */
+  private function pairsOf(iterable $deltas): array {
+    $r= [];
+    foreach ($deltas as $field => $delta) {
+      $r[]= [$field => $delta];
+    }
+    return $r;
+  }
+}

--- a/src/test/php/com/openai/unittest/Streams.class.php
+++ b/src/test/php/com/openai/unittest/Streams.class.php
@@ -51,11 +51,11 @@ trait Streams {
     return new MemoryInputStream(implode("\n\n", $lines));
   }
 
-  /** Maps deltas to a list of pairs */
-  private function pairsOf(iterable $deltas): array {
+  /** Maps an iterable to a list of pairs */
+  private function pairsOf(iterable $iterable): array {
     $r= [];
-    foreach ($deltas as $field => $delta) {
-      $r[]= [$field => $delta];
+    foreach ($iterable as $key => $value) {
+      $r[]= [$key => $value];
     }
     return $r;
   }

--- a/src/test/php/com/openai/unittest/ToolsTest.class.php
+++ b/src/test/php/com/openai/unittest/ToolsTest.class.php
@@ -11,9 +11,12 @@ class ToolsTest {
   /** Returns a testing API endpoint */
   private function testingEndpoint(): TestEndpoint {
     return new TestEndpoint([
-      'POST /echo' => function($call) {
+      'POST /completions' => function($call) {
         return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], $call->content());
-      }
+      },
+      'POST /responses' => function($call) {
+        return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], $call->content());
+      },
     ]);
   }
 
@@ -41,19 +44,36 @@ class ToolsTest {
   }
 
   #[Test]
-  public function serialized_for_rest_api() {
+  public function serialized_for_completions_api() {
     $functions= $this->functions();
     $endpoint= new OpenAIEndpoint($this->testingEndpoint());
-    $result= $endpoint->api('/echo')->invoke(['tools' => new Tools($functions)]);
+    $result= $endpoint->api('/completions')->invoke(['tools' => new Tools($functions)]);
 
     Assert::equals(
       ['tools' => [[
-        'type' => 'function',
+        'type'     => 'function',
         'function' => [
           'name'        => 'greet_world',
           'description' => 'World',
           'parameters'  => $functions->schema()->current()['input'],
         ],
+      ]]],
+      $result
+    );
+  }
+
+  #[Test]
+  public function serialized_for_responses_api() {
+    $functions= $this->functions();
+    $endpoint= new OpenAIEndpoint($this->testingEndpoint());
+    $result= $endpoint->api('/responses')->invoke(['tools' => new Tools($functions)]);
+
+    Assert::equals(
+      ['tools' => [[
+        'type'        => 'function',
+        'name'        => 'greet_world',
+        'description' => 'World',
+        'parameters'  => $functions->schema()->current()['input'],
       ]]],
       $result
     );


### PR DESCRIPTION
Streaming works differently in the reponses API; and is more comparable to the WebSocket API, sending events with types and payloads, and sending deltas as well as the final values, requiring no extra data merging. This pull request adds an `events()` method to yield the event types and its JSON values.

Here's an example of using it in conjunction with the [responses API](https://platform.openai.com/docs/guides/streaming-responses?api-mode=responses):

```php
use com\openai\rest\OpenAIEndpoint;
use util\cmd\Console;

$ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');

$events= $ai->api('/responses')->stream([
  'model' => 'gpt-4o',
  'input' => $argv[1],
]);
foreach ($events as $type => $value) {
  if ('response.output_text.delta' === $type) {
    Console::write($value['delta']);
  }
}
Console::writeLine();
```

See https://github.com/xp-forge/openai/issues/20#issuecomment-2781024531