### PR TITLE
Allow specifying parameters in the RealtimeApi constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ For Azure AI, the setup code is slightly different:
 use com\openai\realtime\RealtimeApi;
 use util\cmd\Console;
 
-$api= new RealtimeApi('wss://example.openai.azure.com/openai/realtime?'.
-  '?api-version=2024-10-01-preview'.
-  '&deployment=gpt-4o-realtime-preview'
-);
+$api= new RealtimeApi('wss://example.openai.azure.com/openai/realtime', [
+  'api-version' => '2024-10-01-preview',
+  'deployment'  => 'gpt-4o-realtime-preview',
+]);
 $session= $api->connect(['api-key' => getenv('AZUREAI_API_KEY')]);
 ```
 

--- a/src/test/php/com/openai/unittest/RealtimeApiTest.class.php
+++ b/src/test/php/com/openai/unittest/RealtimeApiTest.class.php
@@ -33,6 +33,38 @@ class RealtimeApiTest {
   }
 
   #[Test]
+  public function path_accessor() {
+    Assert::equals(
+      '/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01',
+      (new RealtimeApi(self::URI))->path()
+    );
+  }
+
+  #[Test]
+  public function base_and_parameters() {
+    Assert::equals(
+      '/v1/realtime?model=gpt-realtime-2026',
+      (new RealtimeApi('wss://api.openai.com/v1/realtime', ['model' => 'gpt-realtime-2026']))->path()
+    );
+  }
+
+  #[Test]
+  public function addding_parameters() {
+    Assert::equals(
+      '/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01&api-version=2024-10-01-preview',
+      (new RealtimeApi(self::URI, ['api-version' => '2024-10-01-preview']))->path()
+    );
+  }
+
+  #[Test]
+  public function overwriting_parameters() {
+    Assert::equals(
+      '/v1/realtime?model=gpt-realtime-2026',
+      (new RealtimeApi(self::URI, ['model' => 'gpt-realtime-2026']))->path()
+    );
+  }
+
+  #[Test]
   public function connect() {
     $c= new RealtimeApi(new TestingSocket([self::SESSION_CREATED]));
     $c->connect();


### PR DESCRIPTION
Parameters can now (also) be passed as a map instead of having to supply them all inside the URI string, which becomes hard to read when lengthy.

```php
use com\openai\realtime\RealtimeApi;
use util\cmd\Console;

$api= new RealtimeApi('wss://example.openai.azure.com/openai/realtime', [
  'api-version' => '2024-10-01-preview',
  'deployment'  => 'gpt-4o-realtime-preview',
]);
$session= $api->connect(['api-key' => getenv('AZUREAI_API_KEY')]);
```
