### PR TITLE
Support accessing Azure AI V1 API without api-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use util\cmd\Console;
 $ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
 
 Console::writeLine($ai->api('/responses')->invoke([
-  'model' => 'gpt-4o-mini',
+  'model' => 'gpt-5.2',
   'input' => $prompt,
 ]));
 ```
@@ -37,7 +37,7 @@ use util\cmd\Console;
 $ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
 
 $events= $ai->api('/responses')->stream([
-  'model' => 'gpt-4o-mini',
+  'model' => 'gpt-5.2',
   'input' => $prompt,
 ]);
 foreach ($events as $type => $value) {
@@ -195,7 +195,7 @@ $functions= (new Functions())->register('weather', new Weather());
 
 $ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
 $payload= [
-  'model' => 'gpt-4o-mini',
+  'model' => 'gpt-5.2',
   'tools' => new Tools($functions),
   'input' => [['type' => 'message', 'role' => 'user', 'content' => $content]],
 ];
@@ -266,13 +266,17 @@ These endpoints differ slightly in how they are invoked, which is handled by the
 use com\openai\rest\AzureAIEndpoint;
 use util\cmd\Console;
 
+// Using V1 API
+$ai= new AzureAIEndpoint('https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/v1');
+
+// Using API version
 $ai= new AzureAIEndpoint(
   'https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/deployments/mini',
-  '2025-03-01-preview'
+  '2025-04-01-preview'
 );
 
 Console::writeLine($ai->api('/responses')->invoke([
-  'model' => 'gpt-4o-mini',
+  'model' => 'gpt-5.2',
   'input' => $prompt,
 ]));
 ```
@@ -286,14 +290,14 @@ use com\openai\rest\{AzureAIEndpoint, Distributed, ByRemainingRequests};
 use util\cmd\Console;
 
 $endpoints= [
-  new AzureAIEndpoint('https://...@r1.openai.azure.com/openai/deployments/mini', '2024-02-01'),
-  new AzureAIEndpoint('https://...@r2.openai.azure.com/openai/deployments/mini', '2024-02-01'),
+  new AzureAIEndpoint('https://...@r1.openai.azure.com/openai/v1'),
+  new AzureAIEndpoint('https://...@r2.openai.azure.com/openai/v1'),
 ];
 
 $ai= new Distributed($endpoints, new ByRemainingRequests());
 
 Console::writeLine($ai->api('/responses')->invoke([
-  'model' => 'gpt-4o-mini',
+  'model' => 'gpt-5.2',
   'input' => $prompt,
 ]));
 foreach ($endpoints as $i => $endpoint) {
@@ -362,7 +366,7 @@ use util\cmd\Console;
 $ai= new OpenAIEndpoint('https://'.getenv('OPENAI_API_KEY').'@api.openai.com/v1');
 
 $flow= $ai->api('/chat/completions')->flow([
-  'model'    => 'gpt-4o-mini',
+  'model'    => 'gpt-5.2',
   'messages' => [['role' => 'user', 'content' => $prompt]],
 ]);
 foreach ($flow->deltas() as $type => $delta) {

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ $ai= new AzureAIEndpoint('https://'.getenv('AZUREAI_API_KEY').'@example.openai.a
 
 // Using API version
 $ai= new AzureAIEndpoint(
-  'https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/deployments/mini',
+  'https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/deployments/gpt-5.2',
   '2025-04-01-preview'
 );
 

--- a/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
+++ b/src/main/php/com/openai/rest/AzureAIEndpoint.class.php
@@ -30,14 +30,21 @@ class AzureAIEndpoint extends RestEndpoint {
     }
   }
 
+  /** @return string */
+  private function versioned() {
+    return null === $this->version ? '' : '?api-version='.$this->version;
+  }
+
   /** Returns an API */
   public function api(string $path, array $segments= []): Api {
     return new Api(
-      $this->endpoint->resource(ltrim($path, '/').'?api-version='.$this->version, $segments),
+      $this->endpoint->resource(ltrim($path, '/').$this->versioned(), $segments),
       $this->rateLimit
     );
   }
 
   /** @return string */
-  public function toString() { return nameof($this).'(->'.$this->endpoint->base().'?api-version='.$this->version.')'; }
+  public function toString() {
+    return nameof($this).'(->'.$this->endpoint->base().$this->versioned().')';
+  }
 }

--- a/src/main/php/com/openai/rest/RestEndpoint.class.php
+++ b/src/main/php/com/openai/rest/RestEndpoint.class.php
@@ -31,6 +31,18 @@ abstract class RestEndpoint extends ApiEndpoint {
   /** Returns rate limit */
   public function rateLimit(): RateLimit { return $this->rateLimit; }
 
+  /**
+   * Adds headers to be sent with every request
+   *
+   * @param  string|[:string] $arg
+   * @param  ?string $value
+   * @return self
+   */
+  public function with($arg, $value= null) {
+    $this->endpoint->with($arg, $value);
+    return $this;
+  }
+
   /** @return [:var] */
   public function headers() { return $this->endpoint->headers(); }
 

--- a/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
@@ -35,6 +35,22 @@ class AzureAIEndpointTest extends ApiEndpointTest {
   }
 
   #[Test]
+  public function additional_header() {
+    Assert::equals(
+      'preview',
+      $this->fixture(self::URI)->with('aoai-evals', 'preview')->headers()['aoai-evals']
+    );
+  }
+
+  #[Test]
+  public function additional_headers() {
+    Assert::equals(
+      'preview',
+      $this->fixture(self::URI)->with(['aoai-evals' => 'preview'])->headers()['aoai-evals']
+    );
+  }
+
+  #[Test]
   public function string_representation() {
     Assert::equals(
       'com.openai.rest.AzureAIEndpoint(->https://test.openai.azure.com/openai/deployments/omni/)',

--- a/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
+++ b/src/test/php/com/openai/unittest/AzureAIEndpointTest.class.php
@@ -15,13 +15,18 @@ class AzureAIEndpointTest extends ApiEndpointTest {
   }
 
   #[Test]
+  public function no_version_by_default() {
+    Assert::null($this->fixture(self::URI)->version);
+  }
+
+  #[Test]
   public function version() {
-    Assert::equals('2024-02-01', $this->fixture(self::URI, '2024-02-01')->version);
+    Assert::equals('2025-04-01-preview', $this->fixture(self::URI, '2025-04-01-preview')->version);
   }
 
   #[Test]
   public function version_extracted_from_uri() {
-    Assert::equals('2024-02-01', $this->fixture(self::URI.'?api-version=2024-02-01')->version);
+    Assert::equals('2025-04-01-preview', $this->fixture(self::URI.'?api-version=2025-04-01-preview')->version);
   }
 
   #[Test]
@@ -31,6 +36,14 @@ class AzureAIEndpointTest extends ApiEndpointTest {
 
   #[Test]
   public function string_representation() {
+    Assert::equals(
+      'com.openai.rest.AzureAIEndpoint(->https://test.openai.azure.com/openai/deployments/omni/)',
+      $this->fixture(self::URI)->toString()
+    );
+  }
+
+  #[Test]
+  public function string_representation_with_version() {
     Assert::equals(
       'com.openai.rest.AzureAIEndpoint(->https://test.openai.azure.com/openai/deployments/omni/?api-version=2024-02-01)',
       $this->fixture(self::URI, '2024-02-01')->toString()


### PR DESCRIPTION
This pull request makes supplying an api-version (either through the constructor parameter or inside the endpoint URI) optional. This adds support for the Azure AI V1 API.

TL;DR (as per the linked medium article):
> No api-version needed.
> Just use the /openai/v1 endpoint and your deployment name.

## Example

```php
use com\openai\rest\AzureAIEndpoint;
use util\cmd\Console;

// Using V1 API
$ai= new AzureAIEndpoint('https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/v1');

// Using API version
$ai= new AzureAIEndpoint(
  'https://'.getenv('AZUREAI_API_KEY').'@example.openai.azure.com/openai/deployments/gpt-5.2',
  '2025-04-01-preview'
);

Console::writeLine($ai->api('/responses')->invoke([
  'model' => 'gpt-5.2',
  'input' => $prompt,
]));
```

## See also

* https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle#api-evolution
* https://medium.com/@boopathisarvesan/azure-openai-demystifying-model-versions-api-versions-the-new-v1-spec-37ddffd1a15b